### PR TITLE
Add config for using most recent build for assignment score

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,12 @@ slip_unit_name_plural: "days"
 slip_seconds_per_unit: 86400
 slip_grace_period: 0
 
+# Whether to use the build with the max score to assign scores and slip days.
+# If false, then the most recent build will be used to assign scores and slip days.
+# Otherwise, even if a lower score or slip days should have been consumed, the build
+# with the max score will be used and slip days will not be consumed for building.
+use_max_score_build: false
+
 # On/Off switch for the groups feature. You can turn this feature on midway through the semester, if
 # you would like. Once this feature is enabled, you should not switch it off again.
 groups_enabled: false

--- a/ob2/dockergrader/worker.py
+++ b/ob2/dockergrader/worker.py
@@ -140,7 +140,8 @@ class Worker(object):
                     slipunits = slip_units(due_date, started)
                     affected_users = assign_grade_batch(c, owners, job_name, float(score),
                                                         slipunits, build_name, "Automatic build.",
-                                                        "autograder", dont_lower=True)
+                                                        "autograder",
+                                                        dont_lower=config.use_max_score_build)
                     break
             except apsw.Error:
                 self._log("Exception raised while assigning grades", exc=True)


### PR DESCRIPTION
This PR allows the autograder to either use the max score build or most recent build as the student's score for the assignment.

**Problem**
A current problem that CS162 faces is that the autograder does not consume slip days for builds that have an equivalent score and that there are some portions of the project that are not tested by the autograder (project 1 part 1, project 3 part 1). This means students can (and probably have been) turning in those ungraded portions late and are not consuming slip days. We should be consuming slip days for this.

Another problem is that the "submitted" build is unclear. By using the most recent build as the submission, this makes it easier for readers and students to know which build was submitted. This should clarify the FAQ of "when is code style due?" since this is the final submitted build.

**Fix**
Passing `false` into `assign_grade_batch` forces the autograder to consume slip days and use the most recent build's score. This will consume slip days and make which build was submitted more clear.