### PR TITLE
Limit Number of Queued Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 /apsw-*/
 /apsw.zip
+
+.idea

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -111,6 +111,10 @@ timezone: "US/Pacific"
 # need a special AppArmor profile.
 dockergrader_apparmor_profile: ""
 
+# An optional limit on the maximum number of QUEUED or IN_PROGRESS jobs any given source can have.
+# Default is unlimited.
+# max_ongoing_jobs: 1
+
 # The interface to listen on for HTTP requests. If you're using a reverse proxy, you probably want
 # to set this to '127.0.0.1', to prevent direct external access to this web server.
 web_host: "0.0.0.0"

--- a/ob2/util/job_limiter.py
+++ b/ob2/util/job_limiter.py
@@ -1,0 +1,29 @@
+import logging
+
+import ob2.config as config
+from ob2.database import DbCursor
+from ob2.util.build_constants import QUEUED, IN_PROGRESS, FAILED
+from ob2.util.time import now_str
+
+try:
+    MAX_JOBS_ALLOWED = config.max_ongoing_jobs
+    assert isinstance(MAX_JOBS_ALLOWED, int)
+except (KeyError, AssertionError):
+    MAX_JOBS_ALLOWED = None
+
+def rate_limit_fail_build(build_name):
+    assert MAX_JOBS_ALLOWED is not None
+    message = "Cannot have more than {} builds in progress or queued.".format(MAX_JOBS_ALLOWED)
+    with DbCursor() as c:
+        c.execute('''UPDATE builds SET status = ?, updated = ?, log = ?
+                     WHERE build_name = ?''', [FAILED, now_str(), message, build_name])
+
+def should_limit_source(repo_name):
+    if MAX_JOBS_ALLOWED is None:
+        return False
+    with DbCursor() as c:
+        c.execute('''SELECT count(*) FROM builds
+                                WHERE source = ? AND (status = ? OR status = ?)''',
+                  [repo_name, QUEUED, IN_PROGRESS])
+        count = int(c.fetchone()[0])
+        return count > MAX_JOBS_ALLOWED


### PR DESCRIPTION
This is kind of a hack. 

The limit_queued_job utility checks how many IN_PROGESS and QUEUED jobs a source has, and then automatically fails the job if adding it to the queue brings the source over MAX_JOBS_ALLOWED.