### PR TITLE
Build Exceptions

### DIFF
--- a/ob2/config/assignment.py
+++ b/ob2/config/assignment.py
@@ -40,8 +40,8 @@ class Assignment(object):
         parse_time = DateParser.parse
         not_visible_before = parse_time(self.not_visible_before)
         parse_time(self.due_date)
-        if self.exception_policy is not None:
-            for _, policy in self.exception_policy.items():
+        if self.build_exceptions is not None:
+            for _, policy in self.build_exceptions.items():
                 if "start" in policy:
                     parse_time(policy["start"])
                 if "end" in policy:

--- a/ob2/config/assignment.py
+++ b/ob2/config/assignment.py
@@ -14,7 +14,8 @@ class Assignment(object):
               ("start_auto_building", str),
               ("end_auto_building", str),
               ("due_date", str),
-              ("cannot_build_after", str)]
+              ("cannot_build_after", str),
+              ("build_exceptions", dict)]
 
     _index_by_key = {key: index for index, (key, _) in enumerate(schema)}
 
@@ -39,6 +40,14 @@ class Assignment(object):
         parse_time = DateParser.parse
         not_visible_before = parse_time(self.not_visible_before)
         parse_time(self.due_date)
+        if self.exception_policy is not None:
+            for _, policy in self.exception_policy.items():
+                if "start" in policy:
+                    parse_time(policy["start"])
+                if "end" in policy:
+                    parse_time(policy["end"])
+
+        # Make sure dates are in the correct order
         if not self.manual_grading:
             start_auto_building = parse_time(self.start_auto_building)
             end_auto_building = parse_time(self.end_auto_building)

--- a/ob2/config/assignment.py
+++ b/ob2/config/assignment.py
@@ -1,5 +1,16 @@
 from dateutil import parser as DateParser
 
+class AssignmentStudentView(object):
+    def __init__(self, login, assignment):
+        self.login = login
+        self.assignment = assignment
+
+    def __getattr__(self, key):
+        if self.assignment.exceptions is not None:
+            if self.login in self.assignment.exceptions:
+                if key in self.assignment.exceptions[self.login]:
+                    return self.assignment.exceptions[self.login][key]
+        return getattr(self.assignment, key)
 
 class Assignment(object):
     schema = [("name", str),
@@ -15,7 +26,7 @@ class Assignment(object):
               ("end_auto_building", str),
               ("due_date", str),
               ("cannot_build_after", str),
-              ("build_exceptions", dict)]
+              ("exceptions", dict)]
 
     _index_by_key = {key: index for index, (key, _) in enumerate(schema)}
 
@@ -39,24 +50,41 @@ class Assignment(object):
         # Make sure the dates are parsable
         parse_time = DateParser.parse
         not_visible_before = parse_time(self.not_visible_before)
-        parse_time(self.due_date)
-        if self.build_exceptions is not None:
-            for _, policy in self.build_exceptions.items():
-                if "start" in policy:
-                    parse_time(policy["start"])
-                if "end" in policy:
-                    parse_time(policy["end"])
-
-        # Make sure dates are in the correct order
+        due_date = parse_time(self.due_date)
         if not self.manual_grading:
             start_auto_building = parse_time(self.start_auto_building)
             end_auto_building = parse_time(self.end_auto_building)
             cannot_build_after = parse_time(self.cannot_build_after)
             assert (not_visible_before <= start_auto_building <= end_auto_building <=
                     cannot_build_after)
+            if self.exceptions is not None:
+                exception_not_visible_before = not_visible_before
+                exception_due_date = due_date
+                exception_start_auto_building = start_auto_building
+                exception_end_auto_building = end_auto_building
+                exception_cannot_build_after = cannot_build_after
+                for _, exception in self.exceptions.items():
+                    if "not_visible_before" in exception:
+                        exception_not_visible_before = parse_time(exception["not_visible_before"])
+                    if "due_date" in exception:
+                        exception_due_date = parse_time(exception["due_date"])
+                    if "start_auto_building" in exception:
+                        exception_start_auto_building = parse_time(exception["start_auto_building"])
+                    if "end_auto_building" in exception:
+                        exception_end_auto_building = parse_time(exception["end_auto_building"])
+                    if "cannot_build_after" in exception:
+                        exception_cannot_build_after = parse_time(exception["cannot_build_after"])
+                    assert (exception_not_visible_before <= exception_start_auto_building <=
+                            exception_end_auto_building <= exception_cannot_build_after)
 
     def __getattr__(self, key):
         return self.args[self._index_by_key[key]]
+
+    def student_view(self, login):
+        return AssignmentStudentView(login, self)
+
+    def get_student_attr(self, student, key):
+        return getattr(self.student_view(student), key)
 
     def get_fields(self):
         return self.args[:]

--- a/ob2/util/assignments.py
+++ b/ob2/util/assignments.py
@@ -1,4 +1,5 @@
 import ob2.config as config
+from ob2.util.time import now_compare, parse_time
 
 _assignment_name_set = None
 
@@ -8,3 +9,25 @@ def get_assignment_name_set():
     if _assignment_name_set is None:
         _assignment_name_set = {assignment.name for assignment in config.assignments}
     return _assignment_name_set
+
+
+def has_build_exception(assignment, login):
+    """
+    Returns True if the login has a build exception for the given assignment.
+    Build exceptions allow the user to build even after the cannot_build_after deadline.
+    """
+    build_exceptions = assignment.build_exception
+    if build_exceptions is None:
+        return False
+    if login in build_exceptions:
+        exception_policy = build_exceptions[login]
+        if "start" not in exception_policy:
+            start = assignment.start_auto_building
+        else:
+            start = parse_time(exception_policy["start"])
+        if "end" not in exception_policy:
+            end = assignment.cannot_build_after
+        else:
+            end = parse_time(exception_policy["end"])
+        return now_compare(start, end) == 0
+    return False

--- a/ob2/util/assignments.py
+++ b/ob2/util/assignments.py
@@ -9,25 +9,3 @@ def get_assignment_name_set():
     if _assignment_name_set is None:
         _assignment_name_set = {assignment.name for assignment in config.assignments}
     return _assignment_name_set
-
-
-def has_build_exception(assignment, login):
-    """
-    Returns True if the login has a build exception for the given assignment.
-    Build exceptions allow the user to build even after the cannot_build_after deadline.
-    """
-    build_exceptions = assignment.build_exceptions
-    if build_exceptions is None:
-        return False
-    if login in build_exceptions:
-        exception_policy = build_exceptions[login]
-        if "start" not in exception_policy:
-            start = assignment.start_auto_building
-        else:
-            start = parse_time(exception_policy["start"])
-        if "end" not in exception_policy:
-            end = assignment.cannot_build_after
-        else:
-            end = parse_time(exception_policy["end"])
-        return now_compare(start, end) == 0
-    return False

--- a/ob2/util/assignments.py
+++ b/ob2/util/assignments.py
@@ -16,7 +16,7 @@ def has_build_exception(assignment, login):
     Returns True if the login has a build exception for the given assignment.
     Build exceptions allow the user to build even after the cannot_build_after deadline.
     """
-    build_exceptions = assignment.build_exception
+    build_exceptions = assignment.build_exceptions
     if build_exceptions is None:
         return False
     if login in build_exceptions:


### PR DESCRIPTION
In preparation for students with DSP accommodations, this PR adds the build exceptions feature. Build exceptions allow users to build assignments even after the "cannot_build_after" deadline.

In each assignment config, add:

     - name:                 hw0
        [... other configurations omitted ...]
        cannot_build_after:  "2019-03-15 23:59:59 -0800"
        build_exceptions:
            student0:
                start: "2019-03-14 23:59:59 -0800"
                end: "2019-03-17 23:59:59 -0800"
            student1:
                end: "2019-03-17 23:59:59 -0800"
            student3: {}

If start is omitted, then the start is assignment start auto build time. If end is omitted, then end is assignment cannot build after time.

This also serves well for allowing test accounts to submit to the AG before the assignment is visible to the entire class.