### PR TITLE
Let students/TAs stop builds

### DIFF
--- a/ob2/web/blueprints/dashboard/__init__.py
+++ b/ob2/web/blueprints/dashboard/__init__.py
@@ -235,7 +235,7 @@ def builds_one(name):
                            build_info=build_info,
                            **template_common)
 
-@blueprint.route("/dashboard/builds/<name>/stop")
+@blueprint.route("/dashboard/builds/<name>/stop", methods=["POST"])
 @_require_login
 def builds_one_stop(name):
     with DbCursor() as c:

--- a/ob2/web/blueprints/dashboard/templates/dashboard/builds_one.html
+++ b/ob2/web/blueprints/dashboard/templates/dashboard/builds_one.html
@@ -1,5 +1,5 @@
 {% from "macros/datatables.html" import row_build_name, row_status, row_commit, row_message,
-                                        row_source, row_job, row_build_started, row_build_log %}
+                                        row_source, row_job, row_build_started, row_build_log, row_stop_build %}
 {% extends "_dashboard.html" %}
 {% block content %}
 {% for (build_name, status, score, source, commit, message, job, started, log, full_score)
@@ -15,6 +15,7 @@
             {{ row_source(source) }}
             {{ row_job(job) }}
             {{ row_build_started(started) }}
+            {{ row_stop_build(build_name, status) }}
             {{ row_build_log(log) }}
         </tbody>
     </table>

--- a/ob2/web/blueprints/ta/__init__.py
+++ b/ob2/web/blueprints/ta/__init__.py
@@ -385,7 +385,7 @@ def builds_one(name):
                            build_info=build_info,
                            **_template_common())
 
-@blueprint.route("/ta/builds/<name>/stop")
+@blueprint.route("/ta/builds/<name>/stop", methods=["POST"])
 @_require_ta
 def builds_one_stop(name):
     with DbCursor() as c:

--- a/ob2/web/blueprints/ta/__init__.py
+++ b/ob2/web/blueprints/ta/__init__.py
@@ -394,10 +394,9 @@ def builds_one_stop(name):
                      log FROM builds WHERE build_name = ? LIMIT 1''', [name])
         build = c.fetchone()
         build_info = build + (get_assignment_by_name(build[6]).full_score,)
-        template_common = _template_common(c)
-    return render_template("dashboard/builds_one.html",
+    return render_template("ta/builds_one.html",
                            build_info=build_info,
-                           **template_common)
+                           **_template_common())
 
 @blueprint.route("/ta/assignments/")
 @_require_ta

--- a/ob2/web/blueprints/ta/__init__.py
+++ b/ob2/web/blueprints/ta/__init__.py
@@ -385,6 +385,19 @@ def builds_one(name):
                            build_info=build_info,
                            **_template_common())
 
+@blueprint.route("/ta/builds/<name>/stop")
+@_require_ta
+def builds_one_stop(name):
+    with DbCursor() as c:
+        c.execute('''UPDATE builds SET status = 1 WHERE build_name = ?''', [name])
+        c.execute('''SELECT build_name, status, score, source, `commit`, message, job, started,
+                     log FROM builds WHERE build_name = ? LIMIT 1''', [name])
+        build = c.fetchone()
+        build_info = build + (get_assignment_by_name(build[6]).full_score,)
+        template_common = _template_common(c)
+    return render_template("dashboard/builds_one.html",
+                           build_info=build_info,
+                           **template_common)
 
 @blueprint.route("/ta/assignments/")
 @_require_ta

--- a/ob2/web/blueprints/ta/templates/ta/builds_one.html
+++ b/ob2/web/blueprints/ta/templates/ta/builds_one.html
@@ -1,5 +1,5 @@
 {% from "macros/datatables.html" import row_build_name, row_status, row_commit, row_message,
-                                        row_source, row_job, row_build_started, row_build_log %}
+                                        row_source, row_job, row_build_started, row_build_log, row_stop_build %}
 {% extends "_ta.html" %}
 {% block content %}
 {% for (build_name, status, score, source, commit, message, job, started, log, full_score)
@@ -15,6 +15,7 @@
             {{ row_source(source, link_to="ta") }}
             {{ row_job(job, link_to="ta") }}
             {{ row_build_started(started) }}
+            {{ row_stop_build(build_name, status) }}
             {{ row_build_log(log) }}
         </tbody>
     </table>

--- a/ob2/web/templates/macros/datatables.html
+++ b/ob2/web/templates/macros/datatables.html
@@ -46,6 +46,17 @@
     </tr>
 {% endmacro %}
 
+{% macro row_stop_build(build_name, status) %}
+    {% if status != SUCCESS and status != FAILED %}
+        <tr>
+            <td class="mdl-data-table__cell--non-numeric">&nbsp;</td>
+            <td class="mdl-data-table__cell--non-numeric" style="min-width: 120px;">
+                <form action="stop"><button type="submit" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-color--primary">Stop Build</button></form>
+            </td>
+        </tr>
+    {% endif %}
+{% endmacro %}
+
 {% macro cell_commit(commit, source, len=8) %}
     <td class="mdl-data-table__cell--non-numeric">
     {% if commit != None %}

--- a/ob2/web/templates/macros/datatables.html
+++ b/ob2/web/templates/macros/datatables.html
@@ -51,7 +51,10 @@
         <tr>
             <td class="mdl-data-table__cell--non-numeric">&nbsp;</td>
             <td class="mdl-data-table__cell--non-numeric" style="min-width: 120px;">
-                <form action="stop"><button type="submit" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-color--primary">Stop Build</button></form>
+                <form action="stop" method="post">
+                    <input type="hidden" name="_csrf_token" value="{{ generate_csrf_token() }}" />
+                    <button type="submit" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-color--primary">Stop Build</button>
+                </form>
             </td>
         </tr>
     {% endif %}


### PR DESCRIPTION
Adds a button to the detail page for builds, pointing to a new route that updates a build to have "Failed" status.

~~*Note: does **not** actually stop a running job! This only updates the database (not a fix for broken autograder scripts/dockers).*~~ 
EDIT: See reply!

![image](https://user-images.githubusercontent.com/9411368/103968197-4003fc00-5118-11eb-827b-e60a406e1944.png)
