### PR TITLE
Allow TAs to resend repo invites

### DIFF
--- a/ob2/repomanager/__init__.py
+++ b/ob2/repomanager/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 import ob2.config as config
-from ob2.util.github_api import _assign_repo
+from ob2.util.github_api import _assign_repo, _resend_invites
 from ob2.util.resumable_queue import ResumableQueue
 
 
@@ -16,6 +16,8 @@ class Repomanager(ResumableQueue):
         """
         if operation == "assign_repo":
             _assign_repo(*payload)
+        elif operation == "resend_invites":
+            _resend_invites(*payload)
         else:
             logging.warning("Unknown operation requested in repomanager: %s" % operation)
 

--- a/ob2/web/blueprints/ta/templates/ta/repo.html
+++ b/ob2/web/blueprints/ta/templates/ta/repo.html
@@ -21,7 +21,13 @@
             </tr>
         </tbody>
     </table>
-    <h4>Students</h4>
+    <h4>
+        Students
+        <form action="resend" method="post" style="float:right">
+            <input type="hidden" name="_csrf_token" value="{{ generate_csrf_token() }}" />
+            <button type="submit" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-color--primary">Resend Invites</button>
+        </form>
+    </h4>
     <table class="ob2-fullwidth mdl-data-table mdl-js-data-table mdl-shadow--2dp
                   mdl-color--white">
         <thead>


### PR DESCRIPTION
Adds a "Resend Invites" button to the repository view (for student/group repositories).
Resend invites route adds a "resend invites" operation to the repomanager queue.
Creates a new "resend invites" operation in repomanager.

![image](https://user-images.githubusercontent.com/9411368/103972687-4e571580-5122-11eb-9835-320b47e5be10.png)
